### PR TITLE
Fixed broken link for Spring Boot Maven Plugin

### DIFF
--- a/spring-boot-maven-plugin.adoc
+++ b/spring-boot-maven-plugin.adoc
@@ -1,4 +1,4 @@
-The https://github.com/spring-projects/spring-boot/tree/master/spring-boot-tools/spring-boot-maven-plugin[Spring Boot Maven plugin] provides many convenient features:
+The https://github.com/spring-projects/spring-boot/tree/master/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin[Spring Boot Maven plugin] provides many convenient features:
 
 - It collects all the jars on the classpath and builds a single, runnable "über-jar", which makes it more convenient to execute and transport your service.
 - It searches for the `public static void main()` method to flag as a runnable class. 


### PR DESCRIPTION
I assumed that https://github.com/spring-projects/spring-boot/tree/master/spring-boot-project/spring-boot-tools/spring-boot-maven-plugin is now the correct link