### PR TITLE
URL Cleanup

### DIFF
--- a/android_build_system_intro.adoc
+++ b/android_build_system_intro.adoc
@@ -2,5 +2,5 @@ In this section you set up a basic build script and then create a simple applica
 
 NOTE: If you are new to Android projects, before you proceed, refer to link:/guides/gs/android[Installing the Android Development Environment] to help you configure your development environment.
 
-You can use any build system you like when building apps with Spring, but the code you need to work with http://gradle.org[Gradle] and https://maven.apache.org[Maven] is included here. If you're not familiar with either, refer to link:/guides/gs/gradle-android[Building Android Projects with Gradle] or link:/guides/gs/maven-android[Building Android Projects with Maven].
+You can use any build system you like when building apps with Spring, but the code you need to work with https://gradle.org[Gradle] and https://maven.apache.org[Maven] is included here. If you're not familiar with either, refer to link:/guides/gs/gradle-android[Building Android Projects with Gradle] or link:/guides/gs/maven-android[Building Android Projects with Maven].
 

--- a/build_system_intro.adoc
+++ b/build_system_intro.adoc
@@ -1,4 +1,4 @@
 
 :linkattrs:
 
-First you set up a basic build script. You can use any build system you like when building apps with Spring, but the code you need to work with http://gradle.org[Gradle] and https://maven.apache.org[Maven] is included here. If you're not familiar with either, refer to link:/guides/gs/gradle[Building Java Projects with Gradle] or link:/guides/gs/maven[Building Java Projects with Maven].
+First you set up a basic build script. You can use any build system you like when building apps with Spring, but the code you need to work with https://gradle.org[Gradle] and https://maven.apache.org[Maven] is included here. If you're not familiar with either, refer to link:/guides/gs/gradle[Building Java Projects with Gradle] or link:/guides/gs/maven[Building Java Projects with Maven].

--- a/create_android_manifest.adoc
+++ b/create_android_manifest.adoc
@@ -1,3 +1,3 @@
 === Create an Android manifest
 
-The http://developer.android.com/guide/topics/manifest/manifest-intro.html[Android Manifest] contains all the information required to run an Android application, and it cannot build without one.
+The https://developer.android.com/guide/topics/manifest/manifest-intro.html[Android Manifest] contains all the information required to run an Android application, and it cannot build without one.

--- a/footer.adoc
+++ b/footer.adoc
@@ -1,5 +1,5 @@
 
 Want to write a new guide or contribute to an existing one? Check out our https://github.com/spring-guides/getting-started-guides/wiki[contribution guidelines].
 
-IMPORTANT: All guides are released with an ASLv2 license for the code, and an http://creativecommons.org/licenses/by-nd/3.0/[Attribution, NoDerivatives creative commons license] for the writing.
+IMPORTANT: All guides are released with an ASLv2 license for the code, and an https://creativecommons.org/licenses/by-nd/3.0/[Attribution, NoDerivatives creative commons license] for the writing.
 

--- a/prereq_editor_android_buildtools.adoc
+++ b/prereq_editor_android_buildtools.adoc
@@ -1,5 +1,5 @@
  - About 15 minutes
  - A favorite text editor or IDE
- - http://developer.android.com/sdk/index.html[Android SDK]
- - http://maven.apache.org/download.cgi[Maven 3.0] or later
+ - https://developer.android.com/sdk/index.html[Android SDK]
+ - https://maven.apache.org/download.cgi[Maven 3.0] or later
  - An Android device or Emulator

--- a/prereq_editor_jdk_buildtools.adoc
+++ b/prereq_editor_jdk_buildtools.adoc
@@ -4,8 +4,8 @@ ifndef::java_version[:java_version: 1.8]
 
 * About 15 minutes
 * A favorite text editor or IDE
-* http://www.oracle.com/technetwork/java/javase/downloads/index.html[JDK {java_version}] or later
-* http://www.gradle.org/downloads[Gradle 4+] or http://maven.apache.org/download.cgi[Maven 3.2+]
+* https://www.oracle.com/technetwork/java/javase/downloads/index.html[JDK {java_version}] or later
+* https://www.gradle.org/downloads[Gradle 4+] or https://maven.apache.org/download.cgi[Maven 3.2+]
 * You can also import the code straight into your IDE:
 ** link:/guides/gs/sts[Spring Tool Suite (STS)]
 ** link:/guides/gs/intellij-idea/[IntelliJ IDEA]

--- a/prereq_editor_jdk_maven_buildtools.adoc
+++ b/prereq_editor_jdk_maven_buildtools.adoc
@@ -4,6 +4,6 @@ ifndef::java_version[:java_version: 1.8]
 
  - About 15 minutes
  - A favorite text editor or IDE
- - http://www.oracle.com/technetwork/java/javase/downloads/index.html[JDK {java_version}] or later
- - http://maven.apache.org/download.cgi[Maven 3.2+]
+ - https://www.oracle.com/technetwork/java/javase/downloads/index.html[JDK {java_version}] or later
+ - https://maven.apache.org/download.cgi[Maven 3.2+]
  - You can also import the code from this guide as well as view the web page directly into link:/guides/gs/sts[Spring Tool Suite (STS)] and work your way through it from there.


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://creativecommons.org/licenses/by-nd/3.0/ with 1 occurrences migrated to:  
  https://creativecommons.org/licenses/by-nd/3.0/ ([https](https://creativecommons.org/licenses/by-nd/3.0/) result 200).
* [ ] http://developer.android.com/guide/topics/manifest/manifest-intro.html with 1 occurrences migrated to:  
  https://developer.android.com/guide/topics/manifest/manifest-intro.html ([https](https://developer.android.com/guide/topics/manifest/manifest-intro.html) result 200).
* [ ] http://gradle.org with 2 occurrences migrated to:  
  https://gradle.org ([https](https://gradle.org) result 200).
* [ ] http://maven.apache.org/download.cgi with 3 occurrences migrated to:  
  https://maven.apache.org/download.cgi ([https](https://maven.apache.org/download.cgi) result 200).
* [ ] http://www.oracle.com/technetwork/java/javase/downloads/index.html with 2 occurrences migrated to:  
  https://www.oracle.com/technetwork/java/javase/downloads/index.html ([https](https://www.oracle.com/technetwork/java/javase/downloads/index.html) result 200).
* [ ] http://developer.android.com/sdk/index.html with 1 occurrences migrated to:  
  https://developer.android.com/sdk/index.html ([https](https://developer.android.com/sdk/index.html) result 301).
* [ ] http://www.gradle.org/downloads with 1 occurrences migrated to:  
  https://www.gradle.org/downloads ([https](https://www.gradle.org/downloads) result 301).