### PR TITLE
Change Gradle version to match Spring-boot 2.5+

### DIFF
--- a/prereq_editor_jdk_buildtools.adoc
+++ b/prereq_editor_jdk_buildtools.adoc
@@ -5,7 +5,7 @@ ifndef::java_version[:java_version: 1.8]
 * About 15 minutes
 * A favorite text editor or IDE
 * http://www.oracle.com/technetwork/java/javase/downloads/index.html[JDK {java_version}] or later
-* http://www.gradle.org/downloads[Gradle 4+] or http://maven.apache.org/download.cgi[Maven 3.2+]
+* http://www.gradle.org/downloads[Gradle 6.8+] or http://maven.apache.org/download.cgi[Maven 3.2+]
 * You can also import the code straight into your IDE:
 ** link:/guides/gs/sts[Spring Tool Suite (STS)]
 ** link:/guides/gs/intellij-idea/[IntelliJ IDEA]


### PR DESCRIPTION
Most guides are using now Boot 2.5 which has dropped support for Gradle 4, 5 and early versions of 6. Bumping to match.

https://github.com/spring-guides
https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.5-Release-Notes#minimum-requirements-changes