### PR TITLE
fix: remove broken link to WAR file guide

### DIFF
--- a/build_an_executable_jar_with_both.adoc
+++ b/build_an_executable_jar_with_both.adoc
@@ -20,4 +20,4 @@ java -jar target/{project_id}-0.1.0.jar
 ----
 ====
 
-NOTE: The steps described here create a runnable JAR. You can also link:/guides/gs/convert-jar-to-war/[build a classic WAR file].
+


### PR DESCRIPTION
This fix removes a broken link to the "build a classic WAR file" guide, which returns a 404 error. The outdated reference has been deleted from the documentation to improve the user experience and avoid confusion for contributors and readers.

This fix addresses the issue by removing the outdated reference to the WAR file guide

![image](https://github.com/user-attachments/assets/69929993-6673-4618-bd0c-d882ef88b731)

![image](https://github.com/user-attachments/assets/2fa301c4-f1ec-495b-80c2-e49b7a6488d5)

Github Repo referenced to it...

![image](https://github.com/user-attachments/assets/3db6b707-0815-4cfd-bfbc-2d195d48af0a)